### PR TITLE
Fix pointer event consuming

### DIFF
--- a/draggablemenu/src/main/java/com/dokar/draggablemenu/DraggableMenu.kt
+++ b/draggablemenu/src/main/java/com/dokar/draggablemenu/DraggableMenu.kt
@@ -113,7 +113,7 @@ fun DraggableMenu(
         Popup(
             alignment = alignment,
             offset = popupOffset,
-            onDismissRequest = {},
+            onDismissRequest = { state.hideMenu() },
             properties = properties,
         ) {
             val view = LocalView.current

--- a/draggablemenu/src/main/java/com/dokar/draggablemenu/DraggableMenu.kt
+++ b/draggablemenu/src/main/java/com/dokar/draggablemenu/DraggableMenu.kt
@@ -196,6 +196,7 @@ private fun DraggableMenuContent(
                 dampingRatio = Spring.DampingRatioLowBouncy,
                 stiffness = Spring.StiffnessMediumLow,
             ),
+            label = "HoverBar",
         )
 
         val hoverHeight by remember {
@@ -295,6 +296,7 @@ private fun DraggableMenuItemWrapper(
                 stiffness = Spring.StiffnessLow,
             )
         },
+        label = "Scale",
     )
     Box(
         modifier = modifier.graphicsLayer {

--- a/draggablemenu/src/main/java/com/dokar/draggablemenu/DraggableMenuState.kt
+++ b/draggablemenu/src/main/java/com/dokar/draggablemenu/DraggableMenuState.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -71,7 +72,7 @@ class DraggableMenuState(
         private set
     val hoveredItemIndex: Int get() = hoveredItem.index
 
-    private var snappedItemIndex by mutableStateOf(-1)
+    private var snappedItemIndex by mutableIntStateOf(-1)
     private var snappedOffsetY = 0f
 
     internal var containerCoordinates: LayoutCoordinates? by mutableStateOf(null)

--- a/draggablemenu/src/main/java/com/dokar/draggablemenu/ScaleIndication.kt
+++ b/draggablemenu/src/main/java/com/dokar/draggablemenu/ScaleIndication.kt
@@ -26,7 +26,10 @@ internal class ScaleIndication(
     override fun rememberUpdatedInstance(interactionSource: InteractionSource): IndicationInstance {
         val isPressed by interactionSource.collectIsPressedAsState()
 
-        val scale = animateFloatAsState(targetValue = if (isPressed) pressedScale else 1f)
+        val scale = animateFloatAsState(
+            targetValue = if (isPressed) pressedScale else 1f,
+            label = "Scale",
+        )
 
         return remember(scale) {
             ScaleIndicationInstance { scale.value }


### PR DESCRIPTION
Fixes #4 

The menu container taking `Modifier.draggableMenuContainer()` now consumes all pointer event changes while dragging the menu.